### PR TITLE
add docker hub creds and tag image stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,25 @@
 pipeline {
     agent any
     environment {
-        DOCKER_PASSWORD = credentials("docker_password")
+        DOCKER_HUB_CREDS = credentials("docker_hub_creds")
     }
 
     stages {
         stage('Build & Test') {
             steps {
                 sh './gradlew clean build'
+            }
+        }
+
+        stage('Tag image') {
+            steps {
+                script {
+                    GIT_TAG = sh([script: 'git fetch --tag && git tag', returnStdout: true]).trim()
+                    MAJOR_VERSION = sh([script: 'git tag | cut -d . -f 1', returnStdout: true]).trim()
+                    MINOR_VERSION = sh([script: 'git tag | cut -d . -f 2', returnStdout: true]).trim()
+                    PATCH_VERSION = sh([script: 'git tag | cut -d . -f 3', returnStdout: true]).trim()
+                }
+                sh "docker build -t $DOCKER_HUB_CREDS_USR/hello-img:${MAJOR_VERSION}.\$((${MINOR_VERSION} + 1)).${PATCH_VERSION} ."
             }
         }
     }


### PR DESCRIPTION
- change the env variable `DOCKER_PASSWORD` to `DOCKER_HUB_CREDS` to parametrize the username of the docker hub
- use `DOCKER_HUB_CREDS_USR` for username and `DOCKER_HUB_CREDS_PSW` for password inside `Jenkinsfile`
- add basic tag image stage from wiki example