### PR TITLE
fix: docker compose project name on build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
 
         stage ("Deploy & run integration tests") {
             steps {
-                sh "IMAGE_TAG=${env.IMAGE_TAG} DOCKER_HUB_USERNAME=$DOCKER_HUB_CREDS_USR docker-compose up -d hello"
+                sh "IMAGE_TAG=${env.IMAGE_TAG} DOCKER_HUB_USERNAME=$DOCKER_HUB_CREDS_USR docker compose up -d hello"
                 sh "./gradlew testIT"
                 sh "./gradlew testE2E"
             }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '3.1'
+name: service
 services:
   hello:
     image: ${DOCKER_HUB_USERNAME}/hello-img:${IMAGE_TAG}


### PR DESCRIPTION
Fix: Add docker compose project name `service` and update docker compose cli to compose V2.

**Why the problem in the first place?**
Since there isn't an `.env` file which specifies the project name, the project's root directory name will be used.
When we first started this lab, the docker project containing the 3 containers was `service` (the name of the repo). So when we tested the command from our source dir, the docker compose used the `service` project and updated the service image accordingly with the image from docker hub.

**Problem explication**
The jenkins build fetches the new version from main into a dir named `pe_runtime_org_service_main_default` which on the command `docker compose up -d hello` will try to check for a project with the same name to update the image. Since this new project doesn't exists it will create it. Now we have 2 projects on docker:
- one with the new service image (with its own network)
- one with the old service image inactive and the database (with its own network)

Now, since the new image and the db are in 2 different docker projects they can't communicate between them. So the new service will not run properly since it can't access the db.

**Fixes**
One solution can be to tell jenkins to create a new network and link those 2 containers(new image and db), but this will be ugly and messy, which may cause future problems and too much overwhelms.

The solution chosen was to set a project name to be used wherever the project will be deployed with docker compose. As for why we kept the name `service`, which is not really suggestive? Because we already have the project setup and we didn't want to backup the database and move to another.